### PR TITLE
Fix TranslationEditor.html

### DIFF
--- a/Translations/TranslationEditor.html
+++ b/Translations/TranslationEditor.html
@@ -13,14 +13,14 @@
       function save() {
         saveJSON(
           app.current,
-          "translation_" + app.current.languageCode.toLowerCase() + ".json"
+          "translation_" + app.current.languageCode + ".json"
         );
       }
 
       function view() {
         showJSON(
           app.current,
-          "translation_" + app.current.languageCode.toLowerCase() + ".json"
+          "translation_" + app.current.languageCode + ".json"
         );
       }
 


### PR DESCRIPTION
languageCode needs to be capitalized. Not sure why it was toLowerCase()'ing it.


<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [] The changes have been tested locally
- [] There are no breaking changes

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->



* **What is the current behavior?**
<!-- (You can also just link to an open issue here) -->

* **What is the new behavior (if this is a feature change)?**

* **Other information**:
